### PR TITLE
Spelling errors corrected

### DIFF
--- a/assessment.html
+++ b/assessment.html
@@ -323,8 +323,8 @@
                                                             <option value="12"></option>
                                                             <optgroup label="Established">
                                                                 <option value="0">Atropine</option>
-                                                                <option value="1">Pirenzipine</option>
-                                                                <option value="2">Methoctromine</option>
+                                                                <option value="1">Pirenzepine</option>
+                                                                <option value="2">Methoctramine</option>
                                                                 <option value="3">Darifenacin</option>
                                                                 <option value="4">MT-3</option>
                                                                 <option value="5">S-secoverine</option>
@@ -362,8 +362,8 @@
                                                             <option value="12"></option>
                                                             <optgroup label="Established">
                                                                 <option value="0">Atropine</option>
-                                                                <option value="1">Pirenzipine</option>
-                                                                <option value="2">Methoctromine</option>
+                                                                <option value="1">Pirenzepine</option>
+                                                                <option value="2">Methoctramine</option>
                                                                 <option value="3">Darifenacin</option>
                                                                 <option value="4">MT-3</option>
                                                                 <option value="5">S-secoverine</option>
@@ -400,8 +400,8 @@
                                                             <option value="12"></option>
                                                             <optgroup label="Established">
                                                                 <option value="0">Atropine</option>
-                                                                <option value="1">Pirenzipine</option>
-                                                                <option value="2">Methoctromine</option>
+                                                                <option value="1">Pirenzepine</option>
+                                                                <option value="2">Methoctramine</option>
                                                                 <option value="3">Darifenacin</option>
                                                                 <option value="4">MT-3</option>
                                                                 <option value="5">S-secoverine</option>
@@ -438,8 +438,8 @@
                                                             <option value="12"></option>
                                                             <optgroup label="Established">
                                                                 <option value="0">Atropine</option>
-                                                                <option value="1">Pirenzipine</option>
-                                                                <option value="2">Methoctromine</option>
+                                                                <option value="1">Pirenzepine</option>
+                                                                <option value="2">Methoctramine</option>
                                                                 <option value="3">Darifenacin</option>
                                                                 <option value="4">MT-3</option>
                                                                 <option value="5">S-secoverine</option>
@@ -474,8 +474,8 @@
                                                             <option value="12"></option>
                                                             <optgroup label="Established">
                                                                 <option value="0">Atropine</option>
-                                                                <option value="1">Pirenzipine</option>
-                                                                <option value="2">Methoctromine</option>
+                                                                <option value="1">Pirenzepine</option>
+                                                                <option value="2">Methoctramine</option>
                                                                 <option value="3">Darifenacin</option>
                                                                 <option value="4">MT-3</option>
                                                                 <option value="5">S-secoverine</option>
@@ -510,8 +510,8 @@
                                                             <option value="12"></option>
                                                             <optgroup label="Established">
                                                                 <option value="0">Atropine</option>
-                                                                <option value="1">Pirenzipine</option>
-                                                                <option value="2">Methoctromine</option>
+                                                                <option value="1">Pirenzepine</option>
+                                                                <option value="2">Methoctramine</option>
                                                                 <option value="3">Darifenacin</option>
                                                                 <option value="4">MT-3</option>
                                                                 <option value="5">S-secoverine</option>

--- a/development.html
+++ b/development.html
@@ -368,8 +368,8 @@
                                                         <option value="12"></option>
                                                         <optgroup label="Established">
                                                             <option value="0">Atropine</option>
-                                                            <option value="1">Pirenzipine</option>
-                                                            <option value="2">Methoctromine</option>
+                                                            <option value="1">Pirenzepine</option>
+                                                            <option value="2">Methoctramine</option>
                                                             <option value="3">Darifenacin</option>
                                                             <option value="4">MT-3</option>
                                                             <option value="5">S-secoverine</option>
@@ -407,8 +407,8 @@
                                                         <option value="12"></option>
                                                         <optgroup label="Established">
                                                             <option value="0">Atropine</option>
-                                                            <option value="1">Pirenzipine</option>
-                                                            <option value="2">Methoctromine</option>
+                                                            <option value="1">Pirenzepine</option>
+                                                            <option value="2">Methoctramine</option>
                                                             <option value="3">Darifenacin</option>
                                                             <option value="4">MT-3</option>
                                                             <option value="5">S-secoverine</option>
@@ -445,8 +445,8 @@
                                                         <option value="12"></option>
                                                         <optgroup label="Established">
                                                             <option value="0">Atropine</option>
-                                                            <option value="1">Pirenzipine</option>
-                                                            <option value="2">Methoctromine</option>
+                                                            <option value="1">Pirenzepine</option>
+                                                            <option value="2">Methoctramine</option>
                                                             <option value="3">Darifenacin</option>
                                                             <option value="4">MT-3</option>
                                                             <option value="5">S-secoverine</option>
@@ -483,8 +483,8 @@
                                                         <option value="12"></option>
                                                         <optgroup label="Established">
                                                             <option value="0">Atropine</option>
-                                                            <option value="1">Pirenzipine</option>
-                                                            <option value="2">Methoctromine</option>
+                                                            <option value="1">Pirenzepine</option>
+                                                            <option value="2">Methoctramine</option>
                                                             <option value="3">Darifenacin</option>
                                                             <option value="4">MT-3</option>
                                                             <option value="5">S-secoverine</option>
@@ -519,8 +519,8 @@
                                                         <option value="12"></option>
                                                         <optgroup label="Established">
                                                             <option value="0">Atropine</option>
-                                                            <option value="1">Pirenzipine</option>
-                                                            <option value="2">Methoctromine</option>
+                                                            <option value="1">Pirenzepine</option>
+                                                            <option value="2">Methoctramine</option>
                                                             <option value="3">Darifenacin</option>
                                                             <option value="4">MT-3</option>
                                                             <option value="5">S-secoverine</option>
@@ -555,8 +555,8 @@
                                                         <option value="12"></option>
                                                         <optgroup label="Established">
                                                             <option value="0">Atropine</option>
-                                                            <option value="1">Pirenzipine</option>
-                                                            <option value="2">Methoctromine</option>
+                                                            <option value="1">Pirenzepine</option>
+                                                            <option value="2">Methoctramine</option>
                                                             <option value="3">Darifenacin</option>
                                                             <option value="4">MT-3</option>
                                                             <option value="5">S-secoverine</option>


### PR DESCRIPTION
- Occurrences of "Pirenzipine" corrected to "Pirenzepine"
- Occurrences of "Methoctromine" corrected to "Methoctramine"